### PR TITLE
fix 分区十大板块列表的显示错乱问题

### DIFF
--- a/src/net/newsmth/smth/BoardListActivity.java
+++ b/src/net/newsmth/smth/BoardListActivity.java
@@ -376,7 +376,7 @@ public class BoardListActivity extends AppActivity {
 					showArticleList(0, 0, dict.optString("id"), dict.optString("name"));
 				}
 			}else if(m_mode == 3){
-				showArticleList(1, dict.optInt("id"), null, null);
+				showArticleList(1, dict.optInt("id")+1, null, null);
 			}
 		}
 	}


### PR DESCRIPTION
点击“五湖四海”实际会显示上一个列表“休闲娱乐”的板块，依次类推
